### PR TITLE
Minitest基盤の導入

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev dev-mcp up down shell bundle db-migrate
+.PHONY: dev dev-mcp up down shell bundle db-migrate test
 
 DEV_SERVICES=web vite ssr
 COMPOSE_RUN=docker compose run --rm web
@@ -26,3 +26,6 @@ bundle:
 
 db-migrate:
 	$(COMPOSE_RUN) bin/rails db:migrate
+
+test:
+	$(COMPOSE_RUN) bin/rails test

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+
+class UserTest < ActiveSupport::TestCase
+  test "有効なユーザーは保存できる" do
+    user = User.new(
+      name: "山田太郎",
+      email: "taro@example.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+
+    assert user.valid?
+  end
+
+  test "メールアドレスは小文字に正規化される" do
+    user = User.create!(
+      name: "山田太郎",
+      email: "TARO@EXAMPLE.COM",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+
+    assert_equal "taro@example.com", user.reload.email
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,7 @@
+ENV["RAILS_ENV"] ||= "test"
+require_relative "../config/environment"
+require "rails/test_help"
+
+class ActiveSupport::TestCase
+  # フィクスチャは必要になった時点で有効化する
+end


### PR DESCRIPTION
## 変更点サマリ
- Minitestの最小構成を追加し、テスト実行ができる状態にしました
- `User` モデルの簡単なモデルテストを追加しました
- `make test` でコンテナ上のテスト実行ができるようにしました

## 主要な変更ファイル
- Makefile
- test/test_helper.rb
- test/models/user_test.rb

## 手動テスト手順
- `make test` を実行
- ローカルで `bin/rails test` が実行可能であることを確認（任意）
- テスト結果が失敗せず終了することを確認

## 既知の未対応/懸念点
- なし
