### PR TITLE
モデルテストの追加

### DIFF
--- a/app/models/user_list.rb
+++ b/app/models/user_list.rb
@@ -6,5 +6,5 @@ class UserList < ApplicationRecord
   validates :title, presence: true
   validates :position, numericality: { greater_than_or_equal_to: 0 }
   validates :template_id,
-            uniqueness: { scope: :user_id, message: "このリストはすでに自分用に追加済みです" }
+            uniqueness: { scope: :user_id, message: I18n.t("errors.messages.user_list_already_added") }
 end

--- a/app/models/user_list.rb
+++ b/app/models/user_list.rb
@@ -6,5 +6,8 @@ class UserList < ApplicationRecord
   validates :title, presence: true
   validates :position, numericality: { greater_than_or_equal_to: 0 }
   validates :template_id,
-            uniqueness: { scope: :user_id, message: I18n.t("errors.messages.user_list_already_added") }
+            uniqueness: {
+              scope: :user_id,
+              message: ->(_object, _data) { I18n.t("errors.messages.user_list_already_added") }
+            }
 end

--- a/app/models/user_list_item.rb
+++ b/app/models/user_list_item.rb
@@ -2,6 +2,9 @@ class UserListItem < ApplicationRecord
   belongs_to :user_list, counter_cache: true
   belongs_to :template_item, optional: true
 
-  validates :title, presence: { message: I18n.t("errors.messages.user_list_item_title_blank") }
+  validates :title,
+            presence: {
+              message: ->(_object, _data) { I18n.t("errors.messages.user_list_item_title_blank") }
+            }
   validates :position, numericality: { greater_than_or_equal_to: 0 }
 end

--- a/app/models/user_list_item.rb
+++ b/app/models/user_list_item.rb
@@ -2,6 +2,6 @@ class UserListItem < ApplicationRecord
   belongs_to :user_list, counter_cache: true
   belongs_to :template_item, optional: true
 
-  validates :title, presence: { message: "やることを入力してください" }
+  validates :title, presence: { message: I18n.t("errors.messages.user_list_item_title_blank") }
   validates :position, numericality: { greater_than_or_equal_to: 0 }
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -9,3 +9,5 @@ ja:
       review_or_rating_already_exists: "レビューまたは★評価はすでに投稿済みです。内容を編集してください。"
       rating_score_invalid: "★評価は1〜5で選んでください。"
       rating_already_exists: "このリストへの★評価はすでに投稿済みです。内容を編集してください。"
+      user_list_already_added: "このリストはすでに自分用に追加済みです"
+      user_list_item_title_blank: "やることを入力してください"

--- a/test/fixtures/template_items.yml
+++ b/test/fixtures/template_items.yml
@@ -1,0 +1,11 @@
+moving_step1:
+  template: moving
+  title: 住民票の異動
+  description: 転出届と転入届を確認する。
+  position: 0
+
+packing_step1:
+  template: packing
+  title: 使わないものを箱に入れる
+  description: 先に不要なものをまとめる。
+  position: 0

--- a/test/fixtures/template_ratings.yml
+++ b/test/fixtures/template_ratings.yml
@@ -1,0 +1,4 @@
+moving_rating:
+  template: moving
+  user: hanako
+  score: 5

--- a/test/fixtures/template_reviews.yml
+++ b/test/fixtures/template_reviews.yml
@@ -1,0 +1,4 @@
+moving_review:
+  template: moving
+  user: hanako
+  content: とても役立ちました。

--- a/test/fixtures/templates.yml
+++ b/test/fixtures/templates.yml
@@ -1,0 +1,11 @@
+moving:
+  user: taro
+  title: 引越しのやることリスト
+  description: 引越しで必要になるやることをまとめました。
+  author_notes: ""
+
+packing:
+  user: taro
+  title: 荷造りのやることリスト
+  description: 荷造りを進めるためのやることを整理しています。
+  author_notes: ""

--- a/test/fixtures/user_list_items.yml
+++ b/test/fixtures/user_list_items.yml
@@ -1,0 +1,7 @@
+taro_moving_item:
+  user_list: taro_moving_list
+  template_item: moving_step1
+  title: 住民票の異動
+  description: 転出届と転入届を確認する。
+  completed: false
+  position: 0

--- a/test/fixtures/user_lists.yml
+++ b/test/fixtures/user_lists.yml
@@ -1,0 +1,15 @@
+taro_moving_list:
+  user: taro
+  template: moving
+  title: 自分用のやること
+  description: 引越し準備を進める。
+  position: 0
+  user_list_items_count: 1
+
+taro_packing_list:
+  user: taro
+  template: packing
+  title: 荷造りのやること
+  description: 荷造りを進める。
+  position: 1
+  user_list_items_count: 0

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,0 +1,9 @@
+taro:
+  name: Taro Yamada
+  email: taro@example.com
+  password_digest: <%= BCrypt::Password.create("password123") %>
+
+hanako:
+  name: Hanako Suzuki
+  email: hanako@example.com
+  password_digest: <%= BCrypt::Password.create("password123") %>

--- a/test/models/template_item_test.rb
+++ b/test/models/template_item_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+
+class TemplateItemTest < ActiveSupport::TestCase
+  test "フィクスチャのテンプレ項目は有効" do
+    assert template_items(:moving_step1).valid?
+  end
+
+  test "タイトルは必須" do
+    item = template_items(:moving_step1)
+    item.title = ""
+
+    assert_not item.valid?
+  end
+
+  test "positionは0以上が必要" do
+    item = template_items(:moving_step1)
+    item.position = -1
+
+    assert_not item.valid?
+  end
+end

--- a/test/models/template_item_test.rb
+++ b/test/models/template_item_test.rb
@@ -1,21 +1,23 @@
 require "test_helper"
 
 class TemplateItemTest < ActiveSupport::TestCase
+  setup do
+    @item = template_items(:moving_step1)
+  end
+
   test "フィクスチャのテンプレ項目は有効" do
-    assert template_items(:moving_step1).valid?
+    assert @item.valid?
   end
 
   test "タイトルは必須" do
-    item = template_items(:moving_step1)
-    item.title = ""
+    @item.title = ""
 
-    assert_not item.valid?
+    assert_not @item.valid?
   end
 
   test "positionは0以上が必要" do
-    item = template_items(:moving_step1)
-    item.position = -1
+    @item.position = -1
 
-    assert_not item.valid?
+    assert_not @item.valid?
   end
 end

--- a/test/models/template_item_test.rb
+++ b/test/models/template_item_test.rb
@@ -13,11 +13,13 @@ class TemplateItemTest < ActiveSupport::TestCase
     @item.title = ""
 
     assert_not @item.valid?
+    assert_not_empty @item.errors[:title]
   end
 
   test "positionは0以上が必要" do
     @item.position = -1
 
     assert_not @item.valid?
+    assert_not_empty @item.errors[:position]
   end
 end

--- a/test/models/template_item_test.rb
+++ b/test/models/template_item_test.rb
@@ -13,13 +13,13 @@ class TemplateItemTest < ActiveSupport::TestCase
     @item.title = ""
 
     assert_not @item.valid?
-    assert_not_empty @item.errors[:title]
+    assert_includes @item.errors[:title], I18n.t("errors.messages.blank")
   end
 
   test "positionは0以上が必要" do
     @item.position = -1
 
     assert_not @item.valid?
-    assert_not_empty @item.errors[:position]
+    assert_includes @item.errors[:position], I18n.t("errors.messages.greater_than_or_equal_to", count: 0)
   end
 end

--- a/test/models/template_item_test.rb
+++ b/test/models/template_item_test.rb
@@ -5,7 +5,7 @@ class TemplateItemTest < ActiveSupport::TestCase
     @item = template_items(:moving_step1)
   end
 
-  test "フィクスチャのテンプレ項目は有効" do
+  test "フィクスチャのテンプレート項目は有効" do
     assert @item.valid?
   end
 

--- a/test/models/template_rating_test.rb
+++ b/test/models/template_rating_test.rb
@@ -1,26 +1,25 @@
 require "test_helper"
 
 class TemplateRatingTest < ActiveSupport::TestCase
+  setup do
+    @rating = template_ratings(:moving_rating)
+  end
+
   test "フィクスチャの評価は有効" do
-    assert template_ratings(:moving_rating).valid?
+    assert @rating.valid?
   end
 
   test "評価は1から5の範囲" do
-    rating = template_ratings(:moving_rating)
-    rating.score = 0
+    @rating.score = 0
 
-    assert_not rating.valid?
-    assert_includes rating.errors[:score], I18n.t("errors.messages.rating_score_invalid")
+    assert_not @rating.valid?
+    assert_includes @rating.errors[:score], I18n.t("errors.messages.rating_score_invalid")
   end
 
   test "同じユーザーとテンプレートの組み合わせは重複できない" do
-    rating = TemplateRating.new(
-      template: templates(:moving),
-      user: users(:hanako),
-      score: 4
-    )
+    duplicate_rating = @rating.dup
 
-    assert_not rating.valid?
-    assert_includes rating.errors[:base], I18n.t("errors.messages.rating_already_exists")
+    assert_not duplicate_rating.valid?
+    assert_includes duplicate_rating.errors[:base], I18n.t("errors.messages.rating_already_exists")
   end
 end

--- a/test/models/template_rating_test.rb
+++ b/test/models/template_rating_test.rb
@@ -1,0 +1,26 @@
+require "test_helper"
+
+class TemplateRatingTest < ActiveSupport::TestCase
+  test "フィクスチャの評価は有効" do
+    assert template_ratings(:moving_rating).valid?
+  end
+
+  test "評価は1から5の範囲" do
+    rating = template_ratings(:moving_rating)
+    rating.score = 0
+
+    assert_not rating.valid?
+    assert_includes rating.errors[:score], I18n.t("errors.messages.rating_score_invalid")
+  end
+
+  test "同じユーザーとテンプレートの組み合わせは重複できない" do
+    rating = TemplateRating.new(
+      template: templates(:moving),
+      user: users(:hanako),
+      score: 4
+    )
+
+    assert_not rating.valid?
+    assert_includes rating.errors[:base], I18n.t("errors.messages.rating_already_exists")
+  end
+end

--- a/test/models/template_rating_test.rb
+++ b/test/models/template_rating_test.rb
@@ -9,11 +9,13 @@ class TemplateRatingTest < ActiveSupport::TestCase
     assert @rating.valid?
   end
 
-  test "評価は1から5の範囲" do
-    @rating.score = 0
+  test "評価は1から5の範囲外で無効" do
+    [0, 6].each do |invalid_score|
+      @rating.score = invalid_score
 
-    assert_not @rating.valid?
-    assert_includes @rating.errors[:score], I18n.t("errors.messages.rating_score_invalid")
+      assert_not @rating.valid?, "score: #{invalid_score} should be invalid"
+      assert_includes @rating.errors[:score], I18n.t("errors.messages.rating_score_invalid")
+    end
   end
 
   test "同じユーザーとテンプレートの組み合わせは重複できない" do

--- a/test/models/template_review_test.rb
+++ b/test/models/template_review_test.rb
@@ -1,0 +1,34 @@
+require "test_helper"
+
+class TemplateReviewTest < ActiveSupport::TestCase
+  test "フィクスチャのレビューは有効" do
+    assert template_reviews(:moving_review).valid?
+  end
+
+  test "内容は必須" do
+    review = template_reviews(:moving_review)
+    review.content = ""
+
+    assert_not review.valid?
+    assert review.errors[:content].any?
+  end
+
+  test "内容は1000文字以内" do
+    review = template_reviews(:moving_review)
+    review.content = "a" * 1001
+
+    assert_not review.valid?
+    assert review.errors[:content].any?
+  end
+
+  test "同じユーザーとテンプレートの組み合わせは重複できない" do
+    review = TemplateReview.new(
+      template: templates(:moving),
+      user: users(:hanako),
+      content: "重複テスト"
+    )
+
+    assert_not review.valid?
+    assert_includes review.errors[:base], I18n.t("errors.messages.review_already_exists")
+  end
+end

--- a/test/models/template_review_test.rb
+++ b/test/models/template_review_test.rb
@@ -1,24 +1,26 @@
 require "test_helper"
 
 class TemplateReviewTest < ActiveSupport::TestCase
+  setup do
+    @review = template_reviews(:moving_review)
+  end
+
   test "フィクスチャのレビューは有効" do
-    assert template_reviews(:moving_review).valid?
+    assert @review.valid?
   end
 
   test "内容は必須" do
-    review = template_reviews(:moving_review)
-    review.content = ""
+    @review.content = ""
 
-    assert_not review.valid?
-    assert review.errors[:content].any?
+    assert_not @review.valid?
+    assert_includes @review.errors[:content], I18n.t("errors.messages.review_content_blank")
   end
 
   test "内容は1000文字以内" do
-    review = template_reviews(:moving_review)
-    review.content = "a" * 1001
+    @review.content = "a" * 1001
 
-    assert_not review.valid?
-    assert review.errors[:content].any?
+    assert_not @review.valid?
+    assert_includes @review.errors[:content], I18n.t("errors.messages.review_content_too_long")
   end
 
   test "同じユーザーとテンプレートの組み合わせは重複できない" do

--- a/test/models/template_review_test.rb
+++ b/test/models/template_review_test.rb
@@ -24,13 +24,9 @@ class TemplateReviewTest < ActiveSupport::TestCase
   end
 
   test "同じユーザーとテンプレートの組み合わせは重複できない" do
-    review = TemplateReview.new(
-      template: templates(:moving),
-      user: users(:hanako),
-      content: "重複テスト"
-    )
+    duplicate_review = @review.dup
 
-    assert_not review.valid?
-    assert_includes review.errors[:base], I18n.t("errors.messages.review_already_exists")
+    assert_not duplicate_review.valid?
+    assert_includes duplicate_review.errors[:base], I18n.t("errors.messages.review_already_exists")
   end
 end

--- a/test/models/template_review_test.rb
+++ b/test/models/template_review_test.rb
@@ -23,6 +23,12 @@ class TemplateReviewTest < ActiveSupport::TestCase
     assert_includes @review.errors[:content], I18n.t("errors.messages.review_content_too_long")
   end
 
+  test "内容は1000文字でも有効" do
+    @review.content = "a" * 1000
+
+    assert @review.valid?
+  end
+
   test "同じユーザーとテンプレートの組み合わせは重複できない" do
     duplicate_review = @review.dup
 

--- a/test/models/template_test.rb
+++ b/test/models/template_test.rb
@@ -9,10 +9,11 @@ class TemplateTest < ActiveSupport::TestCase
     assert @template.valid?
   end
 
-  test "タイトルは120文字以内" do
+  test "タイトルは120文字を超えると無効" do
     @template.title = "a" * 121
 
     assert_not @template.valid?
+    assert_not_empty @template.errors[:title]
   end
 
   test "タイトルは120文字でも有効" do
@@ -21,10 +22,11 @@ class TemplateTest < ActiveSupport::TestCase
     assert @template.valid?
   end
 
-  test "author_notesは500文字以内" do
+  test "author_notesは500文字を超えると無効" do
     @template.author_notes = "a" * 501
 
     assert_not @template.valid?
+    assert_not_empty @template.errors[:author_notes]
   end
 
   test "author_notesは500文字でも有効" do

--- a/test/models/template_test.rb
+++ b/test/models/template_test.rb
@@ -24,4 +24,10 @@ class TemplateTest < ActiveSupport::TestCase
   test "average_ratingは平均値を返す" do
     assert_in_delta 5.0, @template.average_rating, 0.001
   end
+
+  test "average_ratingは評価がない場合に0.0を返す" do
+    template_without_ratings = templates(:packing)
+
+    assert_equal 0.0, template_without_ratings.average_rating
+  end
 end

--- a/test/models/template_test.rb
+++ b/test/models/template_test.rb
@@ -1,0 +1,27 @@
+require "test_helper"
+
+class TemplateTest < ActiveSupport::TestCase
+  test "フィクスチャのテンプレは有効" do
+    assert templates(:moving).valid?
+  end
+
+  test "タイトルは120文字以内" do
+    template = templates(:moving)
+    template.title = "a" * 121
+
+    assert_not template.valid?
+  end
+
+  test "author_notesは500文字以内" do
+    template = templates(:moving)
+    template.author_notes = "a" * 501
+
+    assert_not template.valid?
+  end
+
+  test "average_ratingは平均値を返す" do
+    template = templates(:moving)
+
+    assert_in_delta 5.0, template.average_rating, 0.001
+  end
+end

--- a/test/models/template_test.rb
+++ b/test/models/template_test.rb
@@ -15,10 +15,22 @@ class TemplateTest < ActiveSupport::TestCase
     assert_not @template.valid?
   end
 
+  test "タイトルは120文字でも有効" do
+    @template.title = "a" * 120
+
+    assert @template.valid?
+  end
+
   test "author_notesは500文字以内" do
     @template.author_notes = "a" * 501
 
     assert_not @template.valid?
+  end
+
+  test "author_notesは500文字でも有効" do
+    @template.author_notes = "a" * 500
+
+    assert @template.valid?
   end
 
   test "average_ratingは平均値を返す" do

--- a/test/models/template_test.rb
+++ b/test/models/template_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 class TemplateTest < ActiveSupport::TestCase
-  test "フィクスチャのテンプレは有効" do
+  test "フィクスチャのテンプレートは有効" do
     assert templates(:moving).valid?
   end
 

--- a/test/models/template_test.rb
+++ b/test/models/template_test.rb
@@ -1,27 +1,27 @@
 require "test_helper"
 
 class TemplateTest < ActiveSupport::TestCase
+  setup do
+    @template = templates(:moving)
+  end
+
   test "フィクスチャのテンプレートは有効" do
-    assert templates(:moving).valid?
+    assert @template.valid?
   end
 
   test "タイトルは120文字以内" do
-    template = templates(:moving)
-    template.title = "a" * 121
+    @template.title = "a" * 121
 
-    assert_not template.valid?
+    assert_not @template.valid?
   end
 
   test "author_notesは500文字以内" do
-    template = templates(:moving)
-    template.author_notes = "a" * 501
+    @template.author_notes = "a" * 501
 
-    assert_not template.valid?
+    assert_not @template.valid?
   end
 
   test "average_ratingは平均値を返す" do
-    template = templates(:moving)
-
-    assert_in_delta 5.0, template.average_rating, 0.001
+    assert_in_delta 5.0, @template.average_rating, 0.001
   end
 end

--- a/test/models/user_list_item_test.rb
+++ b/test/models/user_list_item_test.rb
@@ -22,6 +22,12 @@ class UserListItemTest < ActiveSupport::TestCase
     assert_not @item.valid?
   end
 
+  test "positionは0でも有効" do
+    @item.position = 0
+
+    assert @item.valid?
+  end
+
   test "template_itemがなくても作成できる" do
     item = UserListItem.new(
       user_list: user_lists(:taro_moving_list),

--- a/test/models/user_list_item_test.rb
+++ b/test/models/user_list_item_test.rb
@@ -1,0 +1,34 @@
+require "test_helper"
+
+class UserListItemTest < ActiveSupport::TestCase
+  test "フィクスチャのやることは有効" do
+    assert user_list_items(:taro_moving_item).valid?
+  end
+
+  test "やることのタイトルは必須" do
+    item = user_list_items(:taro_moving_item)
+    item.title = ""
+
+    assert_not item.valid?
+    assert_includes item.errors[:title], "やることを入力してください"
+  end
+
+  test "positionは0以上が必要" do
+    item = user_list_items(:taro_moving_item)
+    item.position = -1
+
+    assert_not item.valid?
+  end
+
+  test "template_itemがなくても作成できる" do
+    item = UserListItem.new(
+      user_list: user_lists(:taro_moving_list),
+      template_item: nil,
+      title: "新しいやること",
+      description: "説明",
+      position: 0
+    )
+
+    assert item.valid?
+  end
+end

--- a/test/models/user_list_item_test.rb
+++ b/test/models/user_list_item_test.rb
@@ -1,23 +1,25 @@
 require "test_helper"
 
 class UserListItemTest < ActiveSupport::TestCase
+  setup do
+    @item = user_list_items(:taro_moving_item)
+  end
+
   test "フィクスチャのやることは有効" do
-    assert user_list_items(:taro_moving_item).valid?
+    assert @item.valid?
   end
 
   test "やることのタイトルは必須" do
-    item = user_list_items(:taro_moving_item)
-    item.title = ""
+    @item.title = ""
 
-    assert_not item.valid?
-    assert_includes item.errors[:title], "やることを入力してください"
+    assert_not @item.valid?
+    assert_includes @item.errors[:title], I18n.t("errors.messages.user_list_item_title_blank")
   end
 
   test "positionは0以上が必要" do
-    item = user_list_items(:taro_moving_item)
-    item.position = -1
+    @item.position = -1
 
-    assert_not item.valid?
+    assert_not @item.valid?
   end
 
   test "template_itemがなくても作成できる" do

--- a/test/models/user_list_item_test.rb
+++ b/test/models/user_list_item_test.rb
@@ -20,6 +20,7 @@ class UserListItemTest < ActiveSupport::TestCase
     @item.position = -1
 
     assert_not @item.valid?
+    assert_not_empty @item.errors[:position]
   end
 
   test "positionは0でも有効" do

--- a/test/models/user_list_test.rb
+++ b/test/models/user_list_test.rb
@@ -10,19 +10,10 @@ class UserListTest < ActiveSupport::TestCase
   end
 
   test "同じユーザーとテンプレートの組み合わせは重複できない" do
-    user = users(:taro)
-    template = templates(:moving)
+    duplicate_list = @user_list.dup
 
-    user_list = UserList.new(
-      user: user,
-      template: template,
-      title: "重複のやること",
-      description: "重複テスト",
-      position: 0
-    )
-
-    assert_not user_list.valid?
-    assert_includes user_list.errors[:template_id], I18n.t("errors.messages.user_list_already_added")
+    assert_not duplicate_list.valid?
+    assert_includes duplicate_list.errors[:template_id], I18n.t("errors.messages.user_list_already_added")
   end
 
   test "positionは0以上が必要" do

--- a/test/models/user_list_test.rb
+++ b/test/models/user_list_test.rb
@@ -20,6 +20,7 @@ class UserListTest < ActiveSupport::TestCase
     @user_list.position = -1
 
     assert_not @user_list.valid?
+    assert_not_empty @user_list.errors[:position]
   end
 
   test "positionは0でも有効" do

--- a/test/models/user_list_test.rb
+++ b/test/models/user_list_test.rb
@@ -1,8 +1,12 @@
 require "test_helper"
 
 class UserListTest < ActiveSupport::TestCase
+  setup do
+    @user_list = user_lists(:taro_moving_list)
+  end
+
   test "フィクスチャの自分用リストは有効" do
-    assert user_lists(:taro_moving_list).valid?
+    assert @user_list.valid?
   end
 
   test "同じユーザーとテンプレートの組み合わせは重複できない" do
@@ -18,13 +22,12 @@ class UserListTest < ActiveSupport::TestCase
     )
 
     assert_not user_list.valid?
-    assert_includes user_list.errors[:template_id], "このリストはすでに自分用に追加済みです"
+    assert_includes user_list.errors[:template_id], I18n.t("errors.messages.user_list_already_added")
   end
 
   test "positionは0以上が必要" do
-    user_list = user_lists(:taro_moving_list)
-    user_list.position = -1
+    @user_list.position = -1
 
-    assert_not user_list.valid?
+    assert_not @user_list.valid?
   end
 end

--- a/test/models/user_list_test.rb
+++ b/test/models/user_list_test.rb
@@ -21,4 +21,10 @@ class UserListTest < ActiveSupport::TestCase
 
     assert_not @user_list.valid?
   end
+
+  test "positionは0でも有効" do
+    @user_list.position = 0
+
+    assert @user_list.valid?
+  end
 end

--- a/test/models/user_list_test.rb
+++ b/test/models/user_list_test.rb
@@ -1,0 +1,30 @@
+require "test_helper"
+
+class UserListTest < ActiveSupport::TestCase
+  test "フィクスチャの自分用リストは有効" do
+    assert user_lists(:taro_moving_list).valid?
+  end
+
+  test "同じユーザーとテンプレートの組み合わせは重複できない" do
+    user = users(:taro)
+    template = templates(:moving)
+
+    user_list = UserList.new(
+      user: user,
+      template: template,
+      title: "重複のやること",
+      description: "重複テスト",
+      position: 0
+    )
+
+    assert_not user_list.valid?
+    assert_includes user_list.errors[:template_id], "このリストはすでに自分用に追加済みです"
+  end
+
+  test "positionは0以上が必要" do
+    user_list = user_lists(:taro_moving_list)
+    user_list.position = -1
+
+    assert_not user_list.valid?
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -4,7 +4,7 @@ class UserTest < ActiveSupport::TestCase
   test "有効なユーザーは保存できる" do
     user = User.new(
       name: "山田太郎",
-      email: "taro@example.com",
+      email: "new_taro@example.com",
       password: "password123",
       password_confirmation: "password123"
     )
@@ -15,11 +15,11 @@ class UserTest < ActiveSupport::TestCase
   test "メールアドレスは小文字に正規化される" do
     user = User.create!(
       name: "山田太郎",
-      email: "TARO@EXAMPLE.COM",
+      email: "Normalize@Example.com",
       password: "password123",
       password_confirmation: "password123"
     )
 
-    assert_equal "taro@example.com", user.reload.email
+    assert_equal "normalize@example.com", user.reload.email
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,5 +3,5 @@ require_relative "../config/environment"
 require "rails/test_help"
 
 class ActiveSupport::TestCase
-  # フィクスチャは必要になった時点で有効化する
+  fixtures :all
 end


### PR DESCRIPTION
## 変更点サマリ
- モデルテスト用のfixturesを追加しました
- 各モデルのバリデーション/関連のテストを追加しました
- `fixtures :all` を有効化し、既存のユーザーテストのメールを調整しました

## 主要な変更ファイル
- test/test_helper.rb
- test/fixtures/users.yml
- test/fixtures/templates.yml
- test/fixtures/template_items.yml
- test/fixtures/template_reviews.yml
- test/fixtures/template_ratings.yml
- test/fixtures/user_lists.yml
- test/fixtures/user_list_items.yml
- test/models/user_list_test.rb
- test/models/user_list_item_test.rb
- test/models/template_test.rb
- test/models/template_item_test.rb
- test/models/template_review_test.rb
- test/models/template_rating_test.rb
- test/models/user_test.rb

## 手動テスト手順
- `make test` を実行
- すべてのモデルテストが失敗せず終了することを確認
- `UserList` の重複防止エラーが想定どおりであることを確認

## 既知の未対応/懸念点
- なし
